### PR TITLE
fix: edit button on the latest date

### DIFF
--- a/src/components/NotificationList.tsx
+++ b/src/components/NotificationList.tsx
@@ -160,6 +160,11 @@ export default function NotificationList() {
     })
   }
 
+  const getLatestDate = () => {
+    const dates = Object.keys(groupedNotifications)
+    return dates.length ? dates.reduce((a, b) => (a > b ? a : b)) : null
+  }
+
   return (
     <>
       {Object.keys(groupedNotifications).length === 0 ? (
@@ -173,9 +178,9 @@ export default function NotificationList() {
             if (dayNotifications && dayNotifications.length > 0) {
               return (
                 <CardList key={index}>
-                  {day === today ? (
+                  {day === today || day === getLatestDate() ? (
                     <TitleContainer>
-                      <DateTitle>Today</DateTitle>
+                      <DateTitle>{day === today ? 'Today' : `Last ${getFullDateString(day)}`}</DateTitle>
                       <EditText>Edit</EditText>
                       <ToggleButton toggle={setToggled} />
                     </TitleContainer>

--- a/src/constants/number.ts
+++ b/src/constants/number.ts
@@ -2,3 +2,8 @@
  * The interval, in seconds, at which the calendar should be updated.
  */
 export const UPDATE_CALENDAR_INTERVAL = 60
+
+/**
+ * The interval, in seconds, at which the notification should be sent.
+ */
+export const NOTIFICATION_INTERVAL = 3600

--- a/src/workers/background.ts
+++ b/src/workers/background.ts
@@ -1,8 +1,8 @@
 import { UPDATE_CALENDAR_INTERVAL } from '../constants/number'
+import { NOTIFICATION_INTERVAL } from '../constants/number'
 import { formatDate, getDateDifference, getDomainNameFromUrl, handleDatesQueue } from '../utils'
 
 const DEFAULT_ICON = '/default.png'
-const NOTIFICATION_INTERVAL = 3600 // seconds
 let checkInterval: NodeJS.Timeout | null = null
 let calendar: CalendarStorageData = {}
 const datesQueue: string[] = []

--- a/src/workers/background.ts
+++ b/src/workers/background.ts
@@ -38,7 +38,7 @@ chrome.storage.local.get('calendar', (data) => {
   } else {
     const today = new Date()
 
-    for (let i = 0; i <= 100; ++i) {
+    for (let i = 0; i < 100; ++i) {
       const currentDate = new Date(today)
       currentDate.setDate(today.getDate() - i)
 


### PR DESCRIPTION
## What's been fixed
The edit button here is not shown on the latest date but only on today.

<img width="407" alt="Screenshot 2023-09-12 at 5 31 01 PM" src="https://github.com/SeiwonPark/time-observer/assets/63793178/6e7b2b8c-e5b5-467f-9945-905a2f233689">
